### PR TITLE
CTRadioAccessTechnologyNR Error Fix

### DIFF
--- a/Tweak/iPad/Diary.x
+++ b/Tweak/iPad/Diary.x
@@ -1520,7 +1520,7 @@ SBFWallpaperView* lockscreenWallpaper = nil;
                 else if ([telephonyInfo.serviceCurrentRadioAccessTechnology[dataServiceIdentifier] isEqual:CTRadioAccessTechnologyHSDPA]) [[coverSheetView diaryCellularTypeLabel] setText:@"3G"];
                 else if ([telephonyInfo.serviceCurrentRadioAccessTechnology[dataServiceIdentifier] isEqual:CTRadioAccessTechnologyHSUPA]) [[coverSheetView diaryCellularTypeLabel] setText:@"3G"];
                 else if ([telephonyInfo.serviceCurrentRadioAccessTechnology[dataServiceIdentifier] isEqual:CTRadioAccessTechnologyeHRPD]) [[coverSheetView diaryCellularTypeLabel] setText:@"3G"];
-                if (@available(iOS 14.0, *)) {
+                if (@available(iOS 14.1, *)) {
                     if ([telephonyInfo.serviceCurrentRadioAccessTechnology[dataServiceIdentifier] isEqual:CTRadioAccessTechnologyNR] || [telephonyInfo.serviceCurrentRadioAccessTechnology[dataServiceIdentifier] isEqual:CTRadioAccessTechnologyNRNSA]) [[coverSheetView diaryCellularTypeLabel] setText:@"5G"];
                 }
             }

--- a/Tweak/iPhone/Diary.x
+++ b/Tweak/iPhone/Diary.x
@@ -1590,7 +1590,7 @@ SBFWallpaperView* lockscreenWallpaper = nil;
                 else if ([telephonyInfo.serviceCurrentRadioAccessTechnology[dataServiceIdentifier] isEqual:CTRadioAccessTechnologyHSDPA]) [[coverSheetView diaryCellularTypeLabel] setText:@"3G"];
                 else if ([telephonyInfo.serviceCurrentRadioAccessTechnology[dataServiceIdentifier] isEqual:CTRadioAccessTechnologyHSUPA]) [[coverSheetView diaryCellularTypeLabel] setText:@"3G"];
                 else if ([telephonyInfo.serviceCurrentRadioAccessTechnology[dataServiceIdentifier] isEqual:CTRadioAccessTechnologyeHRPD]) [[coverSheetView diaryCellularTypeLabel] setText:@"3G"];
-                if (@available(iOS 14.0, *)) {
+                if (@available(iOS 14.1, *)) {
                     if ([telephonyInfo.serviceCurrentRadioAccessTechnology[dataServiceIdentifier] isEqual:CTRadioAccessTechnologyNR] || [telephonyInfo.serviceCurrentRadioAccessTechnology[dataServiceIdentifier] isEqual:CTRadioAccessTechnologyNRNSA]) [[coverSheetView diaryCellularTypeLabel] setText:@"5G"];
                 }
             }


### PR DESCRIPTION
###CTRadioAccessTechnologyNR Error Fix
Apple has updated CTRadioAccessTechnologyNR as being only available on iOS 14.1+ and above now, seen in this [Apple Documentation](https://developer.apple.com/documentation/coretelephony/ctradioaccesstechnologynr/).
Fixed by changing to `if (@available(iOS 14.1, *))` , a check that was preventing compilation
